### PR TITLE
Implement debugging and disable PDF opening for batch

### DIFF
--- a/batch_processor.py
+++ b/batch_processor.py
@@ -18,21 +18,26 @@ class BatchProcessor(QObject):
         self.app = app
 
     def _run_thread_and_wait(self, thread):
+        print(f"[DEBUG] Starting thread {thread.__class__.__name__}")
         loop = QEventLoop()
         thread.finished.connect(loop.quit)
         thread.start()
         loop.exec_()
+        print(f"[DEBUG] Thread {thread.__class__.__name__} finished")
 
     def _process_song(self, title, instrument, key, dest_root):
         app = self.app
+        print(f"[DEBUG] Processing song '{title}' instrument '{instrument}' key '{key}'")
         app.append_log(f"Processing '{title}' - {instrument} in {key}")
 
         # Search for the song
+        print("[DEBUG] Searching for song")
         app.song_search_box.setText(title)
         app.find_songs()
         self._run_thread_and_wait(app.find_songs_thread)
 
         options = [info["text"] for info in app.song_info[:5]]
+        print(f"[DEBUG] Found {len(options)} options")
         if not options:
             app.append_log(f"No results for {title}")
             return True
@@ -44,6 +49,7 @@ class BatchProcessor(QObject):
         pdf_paths = []
         labels = []
         for idx, item in enumerate(options):
+            print(f"[DEBUG] Option {idx}: {item}")
             app.song_choice_box.setCurrentIndex(idx)
             app.select_song()
             self._run_thread_and_wait(app.select_song_thread)
@@ -54,6 +60,7 @@ class BatchProcessor(QObject):
             ]
             chosen_key = key
             if key not in available_keys:
+                print(f"[DEBUG] Requested key '{key}' not in available keys {available_keys}")
                 msg = f"Requested key '{key}' not found. Choose from available keys:\n{', '.join(available_keys)}"
                 suggestions = get_transposition_suggestions(
                     available_keys, instrument, key
@@ -70,11 +77,13 @@ class BatchProcessor(QObject):
                 if not ok:
                     continue
 
+            print(f"[DEBUG] Using key '{chosen_key}'")
             app.key_choice_box.setCurrentText(chosen_key)
             app.select_key()
             self._run_thread_and_wait(app.select_key_thread)
 
             if instrument not in app.instrument_parts:
+                print(f"[DEBUG] Instrument '{instrument}' not found in parts {app.instrument_parts}")
                 instrument, ok = QInputDialog.getItem(
                     app,
                     "Select Instrument",
@@ -87,7 +96,7 @@ class BatchProcessor(QObject):
                     continue
             app.selected_instruments = [instrument]
 
-            app.download_and_process_images()
+            app.download_and_process_images(open_after_download=False)
             self._run_thread_and_wait(app.download_and_process_images_thread)
 
             key_dir = chosen_key
@@ -98,6 +107,7 @@ class BatchProcessor(QObject):
             for fname in os.listdir(song_dir):
                 if fname.endswith(".pdf"):
                     dest_pdf = os.path.join(dest_dir, f"{idx}_{fname}")
+                    print(f"[DEBUG] Moving {fname} to {dest_pdf}")
                     shutil.move(os.path.join(song_dir, fname), dest_pdf)
                     pdf_paths.append(dest_pdf)
                     labels.append(item)
@@ -126,12 +136,16 @@ class BatchProcessor(QObject):
             "Batch_" + datetime.now().strftime("%Y%m%d_%H%M%S"),
         )
         os.makedirs(batch_dir, exist_ok=True)
+        print(f"[DEBUG] Batch directory: {batch_dir}")
 
         for title, instrument, key in entries:
+            print(f"[DEBUG] Starting song '{title}'")
             keep = self._process_song(title, instrument, key, batch_dir)
+            print(f"[DEBUG] Finished song '{title}'")
             if not keep:
                 break
 
         QMessageBox.information(
             self.app, "Batch Complete", "Finished processing song list."
         )
+        print("[DEBUG] Batch processing complete")

--- a/sheet_music_pyqt5.py
+++ b/sheet_music_pyqt5.py
@@ -709,7 +709,8 @@ class App(QMainWindow):
 
 
     @pyqtSlot()
-    def download_and_process_images(self):
+    def download_and_process_images(self, open_after_download=True):
+        print("[DEBUG] download_and_process_images called")
         if not self.key_choice_box.currentText():
             QMessageBox.warning(self, "No Key", "Please select a key before downloading.")
             self.append_log("Please select a key before downloading.")
@@ -730,7 +731,9 @@ class App(QMainWindow):
         selected_instruments = self.selected_instruments.copy()
 
         self.download_and_process_images_thread = DownloadAndProcessThread(
-            driver, key_choice_text, selected_song_title, selected_song_artist, paths, selected_instruments, download_horn_only)
+            driver, key_choice_text, selected_song_title, selected_song_artist,
+            paths, selected_instruments, download_horn_only,
+            open_after_download=open_after_download)
         self.download_and_process_images_thread.log_updated.connect(self.update_log)
         self.download_and_process_images_thread.progress.connect(self.updateProgressBar)
         self.download_and_process_images_thread.status.connect(self.updateStatusLabel)


### PR DESCRIPTION
## Summary
- add extensive debugging prints for batch processing and download threads
- add option to skip auto-opening PDFs after download
- enhance batch processor to use new option
- tests continue to pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d43abbd548323ac56244156151cfd