### PR TITLE
Skip invalid song options

### DIFF
--- a/batch_processor.py
+++ b/batch_processor.py
@@ -63,6 +63,11 @@ class BatchProcessor(QObject):
                 app.key_choice_box.itemText(i)
                 for i in range(app.key_choice_box.count())
             ]
+            if not available_keys:
+                print(
+                    f"[DEBUG] No orchestration found for option {idx}. Skipping."
+                )
+                continue
             chosen_key = key
             if key not in available_keys:
                 print(f"[DEBUG] Requested key '{key}' not in available keys {available_keys}")


### PR DESCRIPTION
## Summary
- prevent batch processor from failing when no orchestration is present
- log and skip to the next song choice when no keys are found

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fae70a93883239e6ca849ab1f9cf9