### PR TITLE
Add detailed Selenium debugging for orchestration lookup

### DIFF
--- a/selenium_utils.py
+++ b/selenium_utils.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
     StaleElementReferenceException,
     TimeoutException,
+    ElementClickInterceptedException,
 )
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -40,11 +41,29 @@ class SeleniumHelper:
     def click_element(driver, xpath, timeout=2, log_func=None):
         try:
             with selenium_lock:
+                if log_func:
+                    log_func(f"[DEBUG] Waiting for element to be clickable: {xpath}")
                 element = WebDriverWait(driver, timeout).until(
                     EC.element_to_be_clickable((By.XPATH, xpath))
                 )
+                if log_func:
+                    log_func(f"[DEBUG] Attempting click on element: {xpath}")
                 element.click()
+                if log_func:
+                    log_func(f"[DEBUG] Click successful on element: {xpath}")
             return True
+        except ElementClickInterceptedException as e:
+            if log_func:
+                log_func(
+                    f"[DEBUG] Element click intercepted at xpath: {xpath} - {str(e)}"
+                )
+                try:
+                    log_func(
+                        f"[DEBUG] Element location: {element.location}, size: {element.size}"
+                    )
+                except Exception:
+                    pass
+            return False
         except (StaleElementReferenceException, NoSuchElementException, TimeoutException) as e:
             if log_func:
                 log_func(f"Error clicking element at xpath: {xpath} - {str(e)}")
@@ -54,9 +73,13 @@ class SeleniumHelper:
     def find_element(driver, xpath, timeout=2, log_func=None):
         try:
             with selenium_lock:
+                if log_func:
+                    log_func(f"[DEBUG] Searching for element: {xpath}")
                 element = WebDriverWait(driver, timeout).until(
                     EC.presence_of_element_located((By.XPATH, xpath))
                 )
+                if log_func:
+                    log_func(f"[DEBUG] Element found: {xpath}")
             return element
         except (StaleElementReferenceException, NoSuchElementException, TimeoutException) as e:
             if log_func:
@@ -67,9 +90,15 @@ class SeleniumHelper:
     def find_elements(driver, xpath, timeout=2, log_func=None):
         try:
             with selenium_lock:
+                if log_func:
+                    log_func(f"[DEBUG] Searching for elements: {xpath}")
                 elements = WebDriverWait(driver, timeout).until(
                     EC.presence_of_all_elements_located((By.XPATH, xpath))
                 )
+                if log_func:
+                    log_func(
+                        f"[DEBUG] Found {len(elements)} elements for xpath: {xpath}"
+                    )
             return elements
         except (StaleElementReferenceException, NoSuchElementException, TimeoutException) as e:
             if log_func:

--- a/sheet_music_threads.py
+++ b/sheet_music_threads.py
@@ -146,12 +146,33 @@ class SelectSongThread(QThread):
                 raise Exception("Error clicking the song.")
 
             chords_click_xpath = xpaths['chords_button']
-            if not SeleniumHelper.click_element(self.driver, chords_click_xpath, log_func=self.log_updated.emit):
+            if not SeleniumHelper.click_element(
+                self.driver, chords_click_xpath, log_func=self.log_updated.emit
+            ):
                 self.log_updated.emit("Error clicking 'Chords & Lyrics' button.")
                 raise Exception("Error clicking 'Chords & Lyrics' button.")
 
             orch_click_xpath = xpaths['orchestration_header']
-            if not SeleniumHelper.click_element(self.driver, orch_click_xpath, log_func=self.log_updated.emit):
+            self.log_updated.emit(
+                f"[DEBUG] Attempting to open orchestration menu using xpath: {orch_click_xpath}"
+            )
+            if not SeleniumHelper.click_element(
+                self.driver, orch_click_xpath, log_func=self.log_updated.emit
+            ):
+                self.log_updated.emit(
+                    "[DEBUG] click_element reported failure for orchestration header"
+                )
+                orch_element = SeleniumHelper.find_element(
+                    self.driver, orch_click_xpath, log_func=self.log_updated.emit
+                )
+                if orch_element:
+                    self.log_updated.emit(
+                        f"[DEBUG] Orchestration header found but not clickable. Location: {orch_element.location}, size: {orch_element.size}"
+                    )
+                else:
+                    self.log_updated.emit(
+                        "[DEBUG] Orchestration header element not present on page."
+                    )
                 self.log_updated.emit("Orchestration not found for this song.")
                 self.song_selection_failed.emit()
                 return


### PR DESCRIPTION
## Summary
- expand SeleniumHelper logging to catch intercepted clicks and report element details
- log element discovery in helper methods for easier troubleshooting
- add verbose diagnostics around orchestration header selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a14e69c2e48323bf349b247e9ca2e1