### PR TITLE
Improve Selenium click handling and instrument debugging

### DIFF
--- a/watermark_remover/download/selenium_utils.py
+++ b/watermark_remover/download/selenium_utils.py
@@ -110,6 +110,18 @@ class SeleniumHelper:
                 except Exception as ex:
                     if log_func:
                         log_func(f"[DEBUG] Failed to save screenshot: {str(ex)}")
+            # Attempt a JavaScript click as a fallback
+            try:
+                with selenium_lock:
+                    driver.execute_script("arguments[0].click();", element)
+                log_func and log_func(
+                    f"[DEBUG] JavaScript click successful on element: {xpath}"
+                )
+                return True
+            except Exception as js_ex:
+                log_func and log_func(
+                    f"[DEBUG] JavaScript click failed on element: {xpath} - {str(js_ex)}"
+                )
             return False
         except (StaleElementReferenceException, NoSuchElementException, TimeoutException) as e:
             if log_func:

--- a/watermark_remover/gui/app.py
+++ b/watermark_remover/gui/app.py
@@ -77,6 +77,8 @@ class App(QMainWindow):
         options = webdriver.ChromeOptions()
         options.add_argument("--start-maximized")
         options.add_argument("--headless")  # Uncomment if you want to run Chrome in headless mode
+        # Explicitly set a large window size so headless Chrome loads full menus
+        options.add_argument("--window-size=1920,1080")
         options.add_argument("--no-sandbox")
         options.add_argument("--disable-gpu")
         options.add_argument("--disable-dev-shm-usage")

--- a/watermark_remover/threads/sheet_music_threads.py
+++ b/watermark_remover/threads/sheet_music_threads.py
@@ -258,6 +258,14 @@ class SelectSongThread(QThread):
             if 'cover' not in part_text.lower() and 'lead sheet' not in part_text.lower():
                 instrument_parts.append(part_text)
 
+        if instrument_parts:
+            formatted_parts = ', '.join(instrument_parts)
+            self.log_updated.emit(
+                f"[DEBUG] Found instrument parts: {formatted_parts}"
+            )
+        else:
+            self.log_updated.emit("[DEBUG] No valid instrument parts found")
+
         if not SeleniumHelper.click_element(self.driver, parts_button_xpath, log_func=self.log_updated.emit):
             self.log_updated.emit("Error closing parts menu.")
             return
@@ -312,6 +320,14 @@ class SelectKeyThread(QThread):
             part_text = part.text.lower()
             if 'cover' not in part_text and 'lead sheet' not in part_text:
                 instrument_parts.append(part.text)
+
+        if instrument_parts:
+            formatted_parts = ', '.join(instrument_parts)
+            self.log_updated.emit(
+                f"[DEBUG] Found instrument parts: {formatted_parts}"
+            )
+        else:
+            self.log_updated.emit("[DEBUG] No valid instrument parts found")
 
         if not SeleniumHelper.click_element(self.driver, parts_button_xpath, log_func=self.log_updated.emit):
             self.log_updated.emit("Error closing parts menu.")
@@ -406,6 +422,14 @@ class DownloadAndProcessThread(QThread):
             if 'cover' not in part_text and 'lead sheet' not in part_text:
                 self.instrument_parts.append(part.text)
 
+        if self.instrument_parts:
+            formatted_parts = ', '.join(self.instrument_parts)
+            self.log_updated.emit(
+                f"[DEBUG] Available instrument parts: {formatted_parts}"
+            )
+        else:
+            self.log_updated.emit("[DEBUG] No valid instrument parts found")
+
         if not SeleniumHelper.click_element(self.driver, parts_button_xpath, log_func=self.log_updated.emit):
             self.log_updated.emit("Error closing parts menu.")
             return
@@ -437,6 +461,7 @@ class DownloadAndProcessThread(QThread):
                 instruments_to_process = self.instrument_parts
 
             for instrument in instruments_to_process:
+                self.log_updated.emit(f"[DEBUG] Processing instrument: {instrument}")
                 if not SeleniumHelper.click_element(self.driver, parts_button_xpath, log_func=self.log_updated.emit):
                     self.log_updated.emit('Error clicking "Parts" button')
                     continue


### PR DESCRIPTION
## Summary
- set explicit 1920x1080 window size for headless Chrome to ensure full menus
- add JavaScript click fallback and intercept debug info in Selenium helper
- log discovered instrument parts and each instrument being processed

## Testing
- `python -m py_compile watermark_remover/download/selenium_utils.py watermark_remover/gui/app.py watermark_remover/threads/sheet_music_threads.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a156cf352c832391031b42153158da